### PR TITLE
put the false statement on cancel event

### DIFF
--- a/src/scripts/Post/PostForm.js
+++ b/src/scripts/Post/PostForm.js
@@ -40,30 +40,29 @@ mainContainer.addEventListener("click", (clickEvent) => {
   if (clickEvent.target.id === "miniMode") {
     setDisplayPostForm(true);
     mainContainer.dispatchEvent(new CustomEvent("stateChanged"));
-  } else {
-    setDisplayPostForm(false);
   }
-});
-
-// Setter(dataAccess)SEND, conditional logic(FEED)READ
-
-mainContainer.addEventListener("click", (clickEvent) => {
-  if (clickEvent.target.id === "submit__button") {
-    const userId = parseInt(localStorage.getItem("gg_user"));
-    const title = document.querySelector("input[name='postTitle']").value;
-    const imageURL = document.querySelector("input[name='postImg']").value;
-    const description = document.querySelector(
-      "input[name='postDescription']"
-    ).value;
-
-    newPost(userId, title, imageURL, description).then(() => {
-      mainContainer.dispatchEvent(new CustomEvent("stateChanged"));
+  });
+  
+  // Setter(dataAccess)SEND, conditional logic(FEED)READ
+  
+  mainContainer.addEventListener("click", (clickEvent) => {
+    if (clickEvent.target.id === "submit__button") {
+      const userId = parseInt(localStorage.getItem("gg_user"));
+      const title = document.querySelector("input[name='postTitle']").value;
+      const imageURL = document.querySelector("input[name='postImg']").value;
+      const description = document.querySelector(
+        "input[name='postDescription']"
+        ).value;
+        
+        newPost(userId, title, imageURL, description).then(() => {
+          mainContainer.dispatchEvent(new CustomEvent("stateChanged"));
+        });
+      }
     });
-  }
-});
-
-mainContainer.addEventListener("click", (clickEvent) => {
-  if (clickEvent.target.id === "cancel__button") {
-    mainContainer.dispatchEvent(new CustomEvent("stateChanged"));
-  }
+    
+    mainContainer.addEventListener("click", (clickEvent) => {
+      if (clickEvent.target.id === "cancel__button") {
+        setDisplayPostForm(false);
+        mainContainer.dispatchEvent(new CustomEvent("stateChanged"));
+      } 
 });


### PR DESCRIPTION
#### Changes Made

1. Put the setDisplayPostForm(false) on the cancel button to ensure that if you click on the DOM it will not respond.

#### Steps to Review

1. Checkout this branch locally.
   ```
   git fetch --all
   git checkout jf-posteventfix
   ```
2. Open a new Terminal and open the giffygram repo (make sure it's named 'giffygram')
3. Run `./serve-giffygram` to serve the code.
4. Test app functionality.
   > Check and see that the mini mode still works, and that the cancel button works. 
5. View code file.
   > Confirm file modifications are present as indicated above.
   > Confirm no unused code or extraneous comments exist.
